### PR TITLE
temporary fix for allowing version to be an object instead of just double

### DIFF
--- a/lib/features/threads/models/thread_feeds/thread_json_meta_data/thread_json_meta_data.dart
+++ b/lib/features/threads/models/thread_feeds/thread_json_meta_data/thread_json_meta_data.dart
@@ -50,7 +50,7 @@ class ThreadJsonMetadata {
   final String? format;
 
   final ContentType? contentType;
-  final double? version;
+  final Object? version;
   final String? question;
   final PollPreferredInterpretation? preferredInterpretation;
   final int? maxChoicesVoted;
@@ -99,7 +99,7 @@ class ThreadJsonMetadata {
                 ? ContentType.poll
                 : ContentType.general,
 
-        version: json?['version'] as double?,
+        version: json?['version'],
         question: json?['question'] as String?,
         choices: asList(json, 'choices').map((e) => e.toString()).toList(),
         filters: json?['filters'] != null ? PollFilters.fromMap(json?['filters']) : null,


### PR DESCRIPTION

<img width="190" alt="Screenshot 2024-10-29 at 23 04 23" src="https://github.com/user-attachments/assets/853b06ba-461c-4a9b-8ab9-7a946cd967f6">
