### PR TITLE
Initialize binding before plugin setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,10 +12,10 @@ import 'package:waves/core/utilities/theme/theme_mode.dart';
 import 'core/dependency_injection/dependency_injection.dart' as get_it;
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await get_it.init();
   await GetStorage.init();
   await EasyLocalization.ensureInitialized();
-  WidgetsFlutterBinding.ensureInitialized();
   PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
   if (packageInfo.version == "1.0.0" && packageInfo.buildNumber == "9") {


### PR DESCRIPTION
## Summary
- ensure `WidgetsFlutterBinding` is initialized before using storage and localization services

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1735dfff8832fbffe3665c21453fa