### PR TITLE
Initialize binding before plugin setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,10 +12,10 @@ import 'package:waves/core/utilities/theme/theme_mode.dart';
 import 'core/dependency_injection/dependency_injection.dart' as get_it;
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await get_it.init();
   await GetStorage.init();
   await EasyLocalization.ensureInitialized();
-  WidgetsFlutterBinding.ensureInitialized();
   PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
   if (packageInfo.version == "1.0.0" && packageInfo.buildNumber == "9") {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+25
+version: 1.1.1+26
 
 environment:
   sdk: '>=3.3.2 <4.0.0'


### PR DESCRIPTION
## Summary
- ensure `WidgetsFlutterBinding` is initialized before using storage and localization services
- bump app version to 1.1.1+26

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1735dfff8832fbffe3665c21453fa