### PR TITLE
fix: hide loader on vote failure

### DIFF
--- a/lib/features/threads/presentation/thread_feed/widgets/upvote/upvote_dialog.dart
+++ b/lib/features/threads/presentation/thread_feed/widgets/upvote/upvote_dialog.dart
@@ -176,27 +176,41 @@ class _UpvoteDialogState extends State<UpvoteDialog> {
   void _postingKeyVoteTransaction(
       UserAuthModel userData, BuildContext context) async {
     widget.rootContext.showLoader();
-    await SignTransactionPostingKeyController().initVoteProcess(weight * 10000,
+    try {
+      await SignTransactionPostingKeyController().initVoteProcess(
+        weight * 10000,
         author: widget.author,
         permlink: widget.permlink,
         authdata: userData as UserAuthModel<PostingAuthModel>,
         onSuccess: () =>
             widget.onSuccess(generateVoteModel(widget.rootContext)),
-        showToast: (message) => widget.rootContext.showSnackBar(message));
-    widget.rootContext.hideLoader();
+        showToast: (message) => widget.rootContext.showSnackBar(message),
+      );
+    } catch (e) {
+      widget.rootContext.showSnackBar(e.toString());
+    } finally {
+      widget.rootContext.hideLoader();
+    }
   }
 
   void _hiveSignerTransaction(
       UserAuthModel userData, BuildContext context) async {
     widget.rootContext.showLoader();
-    await SignTransactionHiveSignerController().initVoteProcess(weight * 10000,
+    try {
+      await SignTransactionHiveSignerController().initVoteProcess(
+        weight * 10000,
         author: widget.author,
         permlink: widget.permlink,
         authdata: userData as UserAuthModel<HiveSignerAuthModel>,
         onSuccess: () =>
             widget.onSuccess(generateVoteModel(widget.rootContext)),
-        showToast: (message) => widget.rootContext.showSnackBar(message));
-    widget.rootContext.hideLoader();
+        showToast: (message) => widget.rootContext.showSnackBar(message),
+      );
+    } catch (e) {
+      widget.rootContext.showSnackBar(e.toString());
+    } finally {
+      widget.rootContext.hideLoader();
+    }
   }
 
   Future<dynamic> _dialogForHiveTransaction(BuildContext context) {


### PR DESCRIPTION
## Summary
- ensure loader closes even if vote operation throws

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a326931f34832f822f2132b411e972