### PR TITLE
Fix timer handling for hive transactions

### DIFF
--- a/lib/core/controllers/hive_transaction_controller.dart
+++ b/lib/core/controllers/hive_transaction_controller.dart
@@ -29,16 +29,15 @@ class HiveTransactionController {
 
   void onSocketSignWait(SocketResponse data, SocketInputType type,
       String accountName, String authKey) {
-    SocketWaitAction.call(
-        data: data,
-        socketInputType: type,
-        listenersProvider: listenersProvider,
-        isHiveKeyChainMethod: ishiveKeyChainMethod,
-        accountName: accountName,
-        authKey: authKey,
-        timer: timer,
-        onTimeOut: () => onServerFailure(message: LocaleText.emTimeOutMessage),
-        resetListeners: resetListeners);
+    timer = SocketWaitAction.call(
+      data: data,
+      socketInputType: type,
+      listenersProvider: listenersProvider,
+      isHiveKeyChainMethod: ishiveKeyChainMethod,
+      accountName: accountName,
+      authKey: authKey,
+      onTimeOut: () => onServerFailure(message: LocaleText.emTimeOutMessage),
+    );
   }
 
   @protected

--- a/lib/core/socket/actions/socket_auth_wait.dart
+++ b/lib/core/socket/actions/socket_auth_wait.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/services.dart';
 import 'package:waves/core/providers/transaction_listeners_providers.dart';
 import 'package:waves/core/socket/models/socket_wait_model.dart';
 import 'package:waves/core/socket/models/socket_response.dart';
@@ -8,16 +7,15 @@ import 'package:waves/core/utilities/act.dart';
 import 'package:waves/core/utilities/enum.dart';
 
 class SocketWaitAction {
-  static void call(
-      {required SocketResponse data,
-      required SocketInputType socketInputType,
-      required TransactionListenersProvider listenersProvider,
-      required bool isHiveKeyChainMethod,
-      required String accountName,
-      required String authKey,
-      required Timer? timer,
-      required VoidCallback onTimeOut,
-      required VoidCallback resetListeners}) {
+  static Timer call({
+    required SocketResponse data,
+    required SocketInputType socketInputType,
+    required TransactionListenersProvider listenersProvider,
+    required bool isHiveKeyChainMethod,
+    required String accountName,
+    required String authKey,
+    required VoidCallback onTimeOut,
+  }) {
     String uuid = data.value;
     String jsonString =
         SocketWaitModel(accountName: accountName, uuid: uuid, authKey: authKey)
@@ -32,7 +30,7 @@ class SocketWaitAction {
     }
     listenersProvider.tickValueListener.value =
         listenersProvider.timeOutValueListener.value;
-    timer = Timer.periodic(const Duration(seconds: 1), (tickValue) {
+    return Timer.periodic(const Duration(seconds: 1), (tickValue) {
       if (listenersProvider.tickValueListener.value == 0) {
         tickValue.cancel();
         onTimeOut();


### PR DESCRIPTION
## Summary
- return timer from `SocketWaitAction.call` and store it in `HiveTransactionController`
- ensure timers can be canceled to avoid spinner hang

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b043c25338832fbf31afbdb115d071