### PR TITLE
Fix tag handling for wave comments

### DIFF
--- a/android/app/src/main/kotlin/com/ecency/waves/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ecency/waves/MainActivity.kt
@@ -108,7 +108,7 @@ class MainActivity : FlutterActivity() {
                 && authKey != null
             ) {
                 webView?.evaluateJavascript(
-                    "commentOnContent('${js(id)}','${js(username)}','${js(author)}','${js(parentPermlink)}','${js(permlink)}','${js(comment)}',$tagsJson,'${js(postingKey)}','${js(token)}','${js(authKey)}');",
+                    "commentOnContent('${js(id)}','${js(username)}','${js(author)}','${js(parentPermlink)}','${js(permlink)}','${js(comment)}','${js(tagsJson)}','${js(postingKey)}','${js(token)}','${js(authKey)}');",
                     null
                 )
             } else if (call.method == "voteContent" && username != null && author != null

--- a/ios/Runner/AppBridge.swift
+++ b/ios/Runner/AppBridge.swift
@@ -128,9 +128,12 @@ class AppBridge: NSObject {
                         debugPrint("username, author, parentPermlink, permlink, comment, postingKey, token, authKey - are note set")
                         return result(FlutterMethodNotImplemented)
                     }
+                    let tagsData = try? JSONSerialization.data(withJSONObject: tags, options: [])
+                    var tagsJson = String(data: tagsData ?? Data(), encoding: .utf8) ?? "[]"
+                    tagsJson = tagsJson.replacingOccurrences(of: "'", with: "\\'")
                     webVC.runThisJS(
                         id: id,
-                        jsCode: "commentOnContent('\(id)','\(username)', '\(author)', '\(parentPermlink)', '\(permlink)', '\(comment)', '\(tags)', '\(postingKey)', '\(token)', '\(authKey)');"
+                        jsCode: "commentOnContent('\(id)','\(username)', '\(author)', '\(parentPermlink)', '\(permlink)', '\(comment)', '\(tagsJson)', '\(postingKey)', '\(token)', '\(authKey)');"
                     ) { text in result(text) }
                 case "voteContent":
                     guard

--- a/ios/Runner/public/index.html
+++ b/ios/Runner/public/index.html
@@ -214,7 +214,7 @@
           title: "",
           body: description,
           json_metadata: JSON.stringify({
-            tags: JSON.parase(tags),
+            tags: JSON.parse(tags),
             app: "ecency-waves",
             format: "markdown+html",
           }),


### PR DESCRIPTION
## Summary
- escape tag arrays when passing to JavaScript bridge on Android
- serialize tag arrays correctly on iOS and fix tag parsing in embedded HTML

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b214f8264c832f9097572ea7040869