### PR TITLE
Improve blockchain transaction confirmation

### DIFF
--- a/.github/workflows/bump-build-number.yml
+++ b/.github/workflows/bump-build-number.yml
@@ -1,0 +1,28 @@
+name: Bump build number
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Increment build number
+        run: |
+          current=$(grep '^version:' pubspec.yaml | sed -E 's/.*\+([0-9]+)/\1/')
+          next=$((current + 1))
+          sed -i -E "s/(version: [0-9]+\.[0-9]+\.[0-9]+\+)[0-9]+/\1$next/" pubspec.yaml
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: increment build number [skip ci]"
+          branch: build-number-bump
+          base: main
+          title: "chore: increment build number"
+          body: "Automated build number bump."

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:   #here we specify the jobs - We could have multiple jobs
   build-android:  #name it something meaningful
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-latest   #runner: select a machine to use
 
     steps:
@@ -68,6 +69,7 @@ jobs:   #here we specify the jobs - We could have multiple jobs
 
 
   build-ios:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
## Summary
- replace Hivexplorer endpoints with direct RPC JSON calls and built-in node fallback
- extend comment broadcast timeout and poll chain to confirm transaction
- add CI workflow that bumps build number via PR to avoid pushing to protected main
- update default RPC nodes to include hive-api.arcange.eu and api.deathwing.me

## Testing
- `dart format lib/core/services/data_service/api_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b38f0f70832fb4438fc599210fd7